### PR TITLE
Fix incorrect time axis ticks and other issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@ configuration on the Web server. Others will be able to see it." >&lt;save&gt;</
                 <td>Units</td>
                 <td>Processing</td>
                 <td>Scale</td>
-                <td>Time (UTC)</td>
+                <td>Time (local)</td>
                 <td>Value</td>
                 <td>Notes</td>
               </tr>


### PR DESCRIPTION
Hi,
I find that the ticks on the time axis are generally inconsistent with the data. It is easy to see that by moving over the data with the cursor and looking at the time field at the top. This fixes it. It also fixes the "Time (UTC)" issue #1 and removes what looked like forgotten debugging code to me. Tested in Chrome 46, FF 41, IE 11.